### PR TITLE
feat: integrate aws secrets loader

### DIFF
--- a/wsi_service/cloud_settings.py
+++ b/wsi_service/cloud_settings.py
@@ -1,52 +1,51 @@
 from datetime import datetime, timedelta
-from typing import Any, Dict
+from typing import Any
 
 from wsi_service.settings import Settings
 
-# Attempt to import a settings client from cloudwrappers. This is a stub
-# that allows future integration when the cloudwrappers package is available.
+# Attempt to import AWS secrets loader from cloudwrappers. Only the AWS portion
+# is used here; dotenv support from that module is intentionally ignored.
 try:  # pragma: no cover - import is optional
-    from wsi_service.utils.cloudwrappers import settings_client  # type: ignore
+    from wsi_service.utils.cloudwrappers.aws_secrets import (  # type: ignore
+        _list_and_get_secrets,
+    )
 except Exception:  # pragma: no cover - fallback for different installation
     try:
-        from utils.cloudwrappers import settings_client  # type: ignore
-    except Exception:  # pragma: no cover - cloudwrappers not installed
-        settings_client = None  # type: ignore
+        from utils.cloudwrappers.aws_secrets import _list_and_get_secrets  # type: ignore
+    except Exception:  # pragma: no cover - aws secrets module not installed
+        _list_and_get_secrets = None  # type: ignore
 
 
 class CloudSettings:
-    """Wrapper around :class:`Settings` that refreshes values from the cloud.
+    """Wrapper around :class:`Settings` that refreshes AWS secrets.
 
-    Values are re-fetched from the cloud every hour. Accessing any attribute
-    triggers a staleness check; if the cached values are more than an hour old
-    we attempt to update them using ``cloudwrappers``. If the client is not
-    available this class simply returns the local ``Settings`` values.
+    Secrets are re-fetched every hour. Accessing any attribute triggers a
+    staleness check; if the cached values are more than an hour old we attempt
+    to refresh them from AWS. If the loader is unavailable this class simply
+    returns the local ``Settings`` values.
     """
 
     def __init__(self) -> None:
-        self._settings = Settings()
-        self._client = getattr(settings_client, "SettingsClient", None)
-        if self._client:
-            self._client = self._client()  # type: ignore[call-arg]
-        # Force an immediate refresh so cloud overrides apply at startup.
         self._last_refresh: datetime = datetime.min
+        self._settings = Settings()
+        # Force an immediate refresh so secrets apply at startup.
         self._refresh()
 
     def _is_stale(self) -> bool:
         return datetime.utcnow() - self._last_refresh > timedelta(hours=1)
 
-    def _refresh(self) -> None:
-        if not self._client:
-            # Nothing to refresh from
-            self._last_refresh = datetime.utcnow()
+    def _load_secrets(self) -> None:
+        if _list_and_get_secrets is None:
             return
-        try:  # pragma: no cover - cloud interaction is stubbed
-            data: Dict[str, Any] = self._client.fetch_settings()  # type: ignore[attr-defined]
+        try:  # pragma: no cover - network interaction is stubbed
+            secrets = _list_and_get_secrets()
         except Exception:
-            data = {}
-        for key, value in data.items():
-            if hasattr(self._settings, key):
-                setattr(self._settings, key, value)
+            secrets = {}
+        # TODO: Map values from ``secrets`` into ``self._settings`` if needed.
+
+    def _refresh(self) -> None:
+        self._load_secrets()
+        self._settings = Settings()
         self._last_refresh = datetime.utcnow()
 
     def __getattr__(self, name: str) -> Any:


### PR DESCRIPTION
## Summary
- integrate optional AWS Secrets Manager loader using `_list_and_get_secrets`
- remove legacy cloudwrappers settings client stub

## Testing
- `pytest` *(fails: unrecognized arguments: --asyncio-mode=strict)*
- `pip install pytest-asyncio` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68c4af1037608323879a1e9ef6e65e72